### PR TITLE
implement usage of external osi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,13 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 option(USE_EXTERNAL_OSI "Use an external version of open_simulation_interface" OFF)
 option(LINK_WITH_SHARED_OSI "Link utils with shared OSI library instead of statically linking" OFF)
 
-# Locate open_simulation_interface using internal or find_package.
+# Locate open_simulation_interface
 if (USE_EXTERNAL_OSI)
-    # if you use this library in your project, you need to add
-    # something lik list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/lib/open-simulation-interface)
-    # to your CMakeLists.txt to find the open_simulation_interface package.
+    # if you use this library in your own project, you need to add
+    # something like list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/lib/open-simulation-interface)
+    # to your CMakeLists.txt so that we can fine the open_simulation_interface package.
     find_package(open_simulation_interface QUIET REQUIRED)
     message(STATUS "Using external OSI, provided by ${open_simulation_interface_DIR}")
-
 else ()
     # Download and use our own open_simulation_interface package.
     include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
-project(osi-utilities)
+project(asam-osi-utilities)
 
-# Som features (e.g. mcap) require at least C++17
+# Some features (e.g. mcap) require at least C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Generate compile_commands.json for clang based tools
@@ -14,20 +14,26 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 option(USE_EXTERNAL_OSI "Use an external version of open_simulation_interface" OFF)
 option(LINK_WITH_SHARED_OSI "Link utils with shared OSI library instead of statically linking" OFF)
 
-# Locate open_simulation_interface using find_package or custom path.
+# Locate open_simulation_interface using internal or find_package.
 if (USE_EXTERNAL_OSI)
-    message(FATAL_ERROR "Not implemented yet")
+    # if you use this library in your project, you need to add
+    # something lik list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/lib/open-simulation-interface)
+    # to your CMakeLists.txt to find the open_simulation_interface package.
+    find_package(open_simulation_interface QUIET REQUIRED)
+    message(STATUS "Using external OSI, provided by ${open_simulation_interface_DIR}")
+
 else ()
     # Download and use our own open_simulation_interface package.
     include(FetchContent)
+    message(STATUS "Using internal OSI, downloading open_simulation_interface...")
     FetchContent_Declare(
             open_simulation_interface
             GIT_REPOSITORY https://github.com/OpenSimulationInterface/open-simulation-interface.git
             GIT_TAG v3.7.0
     )
     FetchContent_MakeAvailable(open_simulation_interface)
-    set(OSI_INCLUDE_DIR ${open_simulation_interface_BINARY_DIR})
 endif ()
+
 
 # option to enable coverage reporting
 option(CODE_COVERAGE "Enable coverage reporting" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,9 @@ if (LINK_WITH_SHARED_OSI)
     target_link_libraries(OSIUtilities PRIVATE open_simulation_interface)
 else ()
     target_link_libraries(OSIUtilities PRIVATE open_simulation_interface_pic)
-    include_directories(${OSI_INCLUDE_DIR})
 endif ()
+include_directories(${open_simulation_interface_BINARY_DIR})
+
 
 # get mcap and its dependencies
 find_package(PkgConfig REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
         ${src_sources}
 )
 target_link_libraries(unit_tests PRIVATE GTest::gtest_main)
+
 # see src/CMakeLists.txt
 target_compile_definitions(unit_tests PRIVATE OSI_TRACE_FILE_SPEC_VERSION="3.7.1")
 
@@ -28,8 +29,9 @@ if (LINK_WITH_SHARED_OSI)
     target_link_libraries(unit_tests PRIVATE open_simulation_interface)
 else ()
     target_link_libraries(unit_tests PRIVATE open_simulation_interface_pic)
-    include_directories(${OSI_INCLUDE_DIR})
 endif ()
+include_directories(${open_simulation_interface_BINARY_DIR})
+
 
 # get mcap and its dependencies
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
#### Reference to a related issue in the repository
<!-- Add the issue number that this PR is addressing -->
closes #9 #11 

#### Add a description
<!-- Add a description of the changes proposed in the pull request -->

This adds the ability to use an external OSI. E.g. in your main (parent) you can now do stuff like 

```cmake
...
# OSI
set(LINK_WITH_SHARED_OSI OFF)
add_subdirectory(lib/open-simulation-interface)
list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/lib/open-simulation-interface)

# asam-osi-utilities
set(USE_EXTERNAL_OSI ON)
add_subdirectory(lib/asam-osi-utilities EXCLUDE_FROM_ALL)
include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/asam-osi-utilities/include)
...
``` 

#### Self-Checks
<!-- Take this checklist as orientation for yourself -->
- [x] I have added unit tests for changed or added functions.
- [x] I have updated function documentation of changed or added functions.
- [x] My changes generate no errors when passing CI tests.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
